### PR TITLE
Repair compiler complaints

### DIFF
--- a/tools/versionclassifier.pl
+++ b/tools/versionclassifier.pl
@@ -20,10 +20,10 @@ sub cmpversion($$)
 { my ($v1, $v2) = @_;
     if($v1->{epoch} ne $v2->{epoch}) {
         return 1;
-    } elsif(my $p = cmpverpart($v1->{ver}, $v2->{ver})) {
-        return $p;
-    } elsif(my $p = cmpverpart($v1->{rel}, $v2->{rel})) {
-        return $p+64;
+    } elsif(my $pv = cmpverpart($v1->{ver}, $v2->{ver})) {
+        return $pv;
+    } elsif(my $pr = cmpverpart($v1->{rel}, $v2->{rel})) {
+        return $pr+64;
     } else {
         return 0;
     }

--- a/tools/versionclassifier.pl
+++ b/tools/versionclassifier.pl
@@ -42,8 +42,13 @@ foreach my $fname (@files) {
 
 foreach my $pkg (sort keys (%{$jsons[0]})) {
     my $p0 = $jsons[0]->{$pkg};
-    my $p1 = $jsons[1]->{$pkg};
-    my $vercmp = cmpversion($p0->{version}, $p1->{version});
-    print "$pkg $p0->{version}{ver} $p1->{version}{ver} $vercmp\n";
+    print "$pkg $p0->{version}{ver} ";
+    if (exists $jsons[1]{$pkg}) {
+        my $p1 = $jsons[1]->{$pkg};
+        my $vercmp = cmpversion($p0->{version}, $p1->{version});
+        print "$p1->{version}{ver} $vercmp\n";
+    } else {
+        print "\n";
+    }
 }
 


### PR DESCRIPTION
More details in the commit message bodies.

Shall I rather print some return number at the end of the output line in case of an "asymmetric" package instead of just ignoring the second version? Wasn't sure if this is parsed by some other tooling.
Also there is a slight uncertainty whether the glob will always read the same files into the same JSON array number, maybe giving the arrays names to indicate whether the missing package is in Slowroll or in Tumbleweed and having the return number based off that would be useful?